### PR TITLE
Add PyPi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,10 +1,8 @@
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: push
 
 jobs:
-
-
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
@@ -13,11 +11,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-        
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Install pypa/build
       run: >-
@@ -35,16 +33,17 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/') 
     needs:
     - build
     runs-on: ubuntu-latest
-
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/markdown-translate-ai
-
+      name: pypi
+      url: https://pypi.org/p/markdown-translate-ai
+    
     permissions:
       id-token: write
 
@@ -55,7 +54,5 @@ jobs:
         name: python-package-distributions
         path: dist/
         
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,59 @@
+name: Publish Python 🐍 distribution 📦 TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/markdown-translate-ai
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows for publishing Python distributions. The most important changes involve setting up a new workflow for publishing to PyPI and renaming an existing workflow for publishing to TestPyPI.

New workflow for publishing to PyPI:

* [`.github/workflows/publish-to-pypi.yml`](diffhunk://#diff-75e8bbdd253f4a71a14114808840e63b6a9c23529499687d148025d860336504R1-R58): Created a new workflow to automate the process of building and publishing Python distributions to PyPI. This includes steps for setting up Python, installing dependencies, building the distribution, and uploading the artifacts.

Renaming and modifying the TestPyPI workflow:

* [`.github/workflows/publish-to-test-pypi.yml`](diffhunk://#diff-589b92445dc6f8ac68673fd9b852b4e366ab69127e791b0fd0c6b43a7a607ac2L1-L7): Renamed the workflow file from `.github/workflows/publish-to-test-pypi.yml.yml` to `.github/workflows/publish-to-test-pypi.yml` and updated the workflow name to "Publish Python 🐍 distribution 📦 TestPyPI."